### PR TITLE
simlf/area-64-create-discord-database-schema

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -7,6 +7,8 @@ import { AuthModule } from './auth/auth.module';
 import { UserEntity } from './users/entity/UserEntity';
 import { HttpModule } from '@nestjs/axios';
 import { UsersModule } from './users/users.module';
+import { DiscordAuthEntity } from './auth/entities/DiscordAuthEntity';
+import { DiscordModule } from './auth/discord/discord.module';
 
 @Module({
   imports: [
@@ -19,10 +21,10 @@ import { UsersModule } from './users/users.module';
       username: 'root',
       password: 'root',
       database: 'area_database',
-      entities: [UserEntity],
+      entities: [UserEntity, DiscordAuthEntity],
       synchronize: true,
     }),
-    // PassportModule.register({ session: true }),
+    DiscordModule,
   ],
   controllers: [
     AppController,

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -11,7 +11,8 @@ import { UserDto } from 'src/users/dto/user.dto';
 
 @Injectable()
 export class AuthService {
-    constructor(private readonly usersService: UsersService, private readonly jwtService: JwtService,  ) {}
+    constructor(private readonly usersService: UsersService,
+    private readonly jwtService: JwtService) {}
 
     async register(userDto: CreateUserDto): Promise<RegistrationStatus> {
         let status: RegistrationStatus = {

--- a/server/src/auth/discord/discord.controller.ts
+++ b/server/src/auth/discord/discord.controller.ts
@@ -1,0 +1,25 @@
+import { Body, Controller, Get, Post, Req, UseGuards } from '@nestjs/common';
+import { DiscordService } from './discord.service';
+import { UserDto } from 'src/users/dto/user.dto';
+import { CreateDiscordDto } from './dto/discord.create.dto';
+import { DiscordDto } from './dto/discord.dto';
+import { AuthGuard } from '@nestjs/passport';
+
+@Controller('discord')
+export class DiscordController {
+    constructor(private readonly discordService: DiscordService) {}
+
+    @Post()
+    @UseGuards(AuthGuard())
+    async create(@Body() createDiscordDto: CreateDiscordDto, @Req() req: any): Promise<DiscordDto> {
+        const user = <UserDto>req.user;
+        return await this.discordService.createDiscordAuth(user, createDiscordDto);
+    }
+
+    @Get()
+    @UseGuards(AuthGuard())
+    async status(@Req() req: any): Promise<DiscordDto> {
+        const user = <UserDto>req.user;
+        return await this.discordService.getDiscordAuth(user);
+    }
+}

--- a/server/src/auth/discord/discord.module.ts
+++ b/server/src/auth/discord/discord.module.ts
@@ -1,0 +1,27 @@
+import { Module } from '@nestjs/common';
+import { DiscordController } from './discord.controller';
+import { DiscordService } from './discord.service';
+import { UsersModule } from 'src/users/users.module';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DiscordAuthEntity } from '../entities/DiscordAuthEntity';
+import { UserEntity } from 'src/users/entity/UserEntity';
+import { AuthModule } from '../auth.module';
+
+@Module({
+    imports: [
+        UsersModule,
+        AuthModule,
+        TypeOrmModule.forFeature([
+            DiscordAuthEntity,
+            UserEntity
+        ]),
+    ],
+    controllers: [
+        DiscordController,
+    ],
+    providers: [
+        DiscordService,
+    ],
+})
+
+export class DiscordModule {}

--- a/server/src/auth/discord/discord.service.ts
+++ b/server/src/auth/discord/discord.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { UserDto } from 'src/users/dto/user.dto';
+import { toDiscordDto } from 'src/utils/mapper';
+import { Repository } from 'typeorm';
+import { DiscordAuthEntity } from 'src/auth/entities/DiscordAuthEntity';
+import { CreateDiscordDto } from './dto/discord.create.dto';
+import { DiscordDto } from './dto/discord.dto';
+import { UsersService } from 'src/users/users.service';
+
+@Injectable()
+export class DiscordService {
+    constructor(
+        private readonly usersService: UsersService,
+        @InjectRepository(DiscordAuthEntity) private readonly discordAuthRepo: Repository<DiscordAuthEntity>,
+    ){}
+
+    async createDiscordAuth({ username }: UserDto, createDiscordDto: CreateDiscordDto): Promise<DiscordDto> {
+        const { accessToken, refreshToken, discordId } = createDiscordDto;
+        const user = await this.usersService.findOne({ where: { username } });
+        const discordAuth: DiscordAuthEntity = await this.discordAuthRepo.create({ accessToken, refreshToken, discordId, user });
+
+        await this.discordAuthRepo.save(discordAuth);
+        return toDiscordDto(discordAuth);
+
+    }
+
+    async getDiscordAuth({ username }: UserDto): Promise<DiscordDto> {
+        const user = await this.usersService.findOne({ where: { username } });
+        const discordAuth = await this.discordAuthRepo.findOne({ where: { user } });
+
+        return toDiscordDto(discordAuth);
+    }
+}

--- a/server/src/auth/discord/dto/discord.create.dto.ts
+++ b/server/src/auth/discord/dto/discord.create.dto.ts
@@ -1,0 +1,6 @@
+export class CreateDiscordDto {
+    id: string;
+    accessToken: string;
+    refreshToken: string;
+    discordId: string;
+}

--- a/server/src/auth/discord/dto/discord.dto.ts
+++ b/server/src/auth/discord/dto/discord.dto.ts
@@ -1,0 +1,6 @@
+export class DiscordDto {
+    id: string;
+    accessToken: string;
+    refreshToken: string;
+    discordId: string;
+}

--- a/server/src/auth/entities/DiscordAuthEntity.ts
+++ b/server/src/auth/entities/DiscordAuthEntity.ts
@@ -1,0 +1,21 @@
+import { UserEntity } from 'src/users/entity/UserEntity';
+import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn, Relation } from 'typeorm';
+
+@Entity({ name: 'discord_auth' })
+export class DiscordAuthEntity {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column()
+    accessToken: string;
+
+    @Column()
+    refreshToken: string;
+
+    @Column()
+    discordId: string;
+
+    @OneToOne(() => UserEntity, (user) => user.discordAuth)
+    @JoinColumn()
+    user: Relation<UserEntity>;
+}

--- a/server/src/users/entity/UserEntity.ts
+++ b/server/src/users/entity/UserEntity.ts
@@ -1,5 +1,6 @@
 import * as bcryptjs from 'bcryptjs';
-import { BeforeInsert, Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { DiscordAuthEntity } from 'src/auth/entities/DiscordAuthEntity';
+import { BeforeInsert, Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn, Relation } from 'typeorm';
 
 @Entity({ name: 'users' })
 export class UserEntity {
@@ -14,6 +15,9 @@ export class UserEntity {
 
   @Column()
   password: string;
+
+  @OneToOne(() => DiscordAuthEntity, (discordAuth) => discordAuth.user)
+  discordAuth: Relation<DiscordAuthEntity>;
 
   @BeforeInsert()
   async hashPassword() {

--- a/server/src/utils/mapper.ts
+++ b/server/src/utils/mapper.ts
@@ -1,3 +1,5 @@
+import { DiscordDto } from "src/auth/discord/dto/discord.dto";
+import { DiscordAuthEntity } from "src/auth/entities/DiscordAuthEntity";
 import { UserDto } from "src/users/dto/user.dto";
 import { UserEntity } from "src/users/entity/UserEntity";
 
@@ -5,4 +7,10 @@ export const toUserDto = (data: UserEntity): UserDto => {
     const { id, email, username } = data;
     let userDto: UserDto = { id, email, username };
     return userDto;
+};
+
+export const toDiscordDto = (data: DiscordAuthEntity): DiscordDto => {
+    const { id, accessToken, refreshToken, discordId } = data;
+    let discordDto: DiscordDto = { id, accessToken, refreshToken, discordId };
+    return discordDto;
 };


### PR DESCRIPTION
- area-64-create-discord-database-schema 🗃️ Create DiscordAuth db schema with OneToOne relation w/User
- area-64-create-discord-database-schema :recycle: Add Discord dependencies"
- area-64-create-discord-database-schema :sparkles: Add discord /register and /login routes
- area-64-create-discord-database-schema :recycle: Fix bad indentation
